### PR TITLE
Hotfix - Replaced window.alert() to Main process' dialog

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { setIpcBoringRepository } from './mainArea/ipcHandlers/ipcBoringReposito
 import { setIpcProjectIOHandler } from './mainArea/ipcHandlers/ipcProjectFile';
 import { setIpcTopoRepository } from './mainArea/ipcHandlers/ipcTopoRepository';
 import { UIController } from './mainArea/appController/uicontroller/uicontroller';
+import { setIpcModalControl } from './mainArea/ipcHandlers/ipcModalHandlers';
 
 if (require('electron-squirrel-startup')) app.quit();
 
@@ -100,6 +101,8 @@ app.on('ready', () => {
   setIpcProjectIOHandler(ipcMain);
 
   setIpcTopoRepository(ipcMain);
+
+  setIpcModalControl(ipcMain);
 });
 
 app.on('window-all-closed', () => {

--- a/src/mainArea/ipcHandlers/ipcModalHandlers.ts
+++ b/src/mainArea/ipcHandlers/ipcModalHandlers.ts
@@ -1,0 +1,13 @@
+import { dialog, IpcMain } from "electron";
+import { UIController } from "../appController/uicontroller/uicontroller";
+
+export const setIpcModalControl = (ipcMain: IpcMain) => {
+    ipcMain.handle('call-dialog-error', async (_, title, message) => {
+        await dialog.showMessageBox(UIController.instance.getWindow('main-window'), {
+            type: "error",
+            title: title,
+            message: message,
+            buttons: ["OK"],
+        });
+    });
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -36,4 +36,5 @@ contextBridge.exposeInMainWorld('electronTopoLayerAPI', {
 
 contextBridge.exposeInMainWorld('electronSystemAPI', {
     receiveOSInfo: (callback) => ipcRenderer.on('os-info', (_event, osInfo) => callback(osInfo)),
+    callDialogError: (title: string, message: string) => ipcRenderer.invoke('call-dialog-error', title, message),
 });

--- a/src/rendererArea/api/ipc/ipcSystemAPI.ts
+++ b/src/rendererArea/api/ipc/ipcSystemAPI.ts
@@ -1,5 +1,6 @@
 export interface IElectronIPCSystemAPI {
     receiveOSInfo: (callback) => void;
+    callDialogError: (title:string, message: string) => Promise<void>;
 }
 
 declare global {

--- a/src/rendererArea/api/three/exporters/threeExporter.ts
+++ b/src/rendererArea/api/three/exporters/threeExporter.ts
@@ -143,7 +143,7 @@ export class ThreeExporter {
         const boringFetch = await window.electronBoringDataAPI.fetchAllBorings();
         const layerFetch = await window.electronBoringDataAPI.getAllLayerColors();
         if(!boringFetch || !boringFetch.result || !layerFetch || !layerFetch.result) {
-            alert('내보내기 오류.');
+            await window.electronSystemAPI.callDialogError('DXF 내보내기 오류', '내보내기 오류.');
             return;
         }
 

--- a/src/rendererArea/sidebar/pages/editor/EditorPage.tsx
+++ b/src/rendererArea/sidebar/pages/editor/EditorPage.tsx
@@ -103,12 +103,12 @@ export const BoringManager = () => {
         let boringName: string;
         if(namingMode == 'autoincrement') {
             if(!prefixRef.current.value || prefixRef.current.value.length == 0) {
-                alert('접두어를 입력해 주세요');
+                await window.electronSystemAPI.callDialogError('시추공 추가 오류', '접두어를 입력해 주세요');
                 return;
             }
     
             if(!indexRef.current.value || parseInt(indexRef.current.value) == 0) {
-                alert('시작번호를 1보다 큰 정수로 입력해 주세요');
+                await window.electronSystemAPI.callDialogError('시추공 번호 오류', '시작번호를 1보다 큰 정수로 입력해 주세요');
                 return;
             }
     
@@ -135,12 +135,12 @@ export const BoringManager = () => {
             const searchJob = await searchBoringName(inputName);
             
             if(searchJob == 'found') {
-                alert('이미 사용중인 이름입니다.');
+                await window.electronSystemAPI.callDialogError('시추공 중복 오류', '이미 사용중인 이름입니다.');
                 return;
             }
 
             if(searchJob == 'internalError') {
-                alert('시스템 내부 오류.');
+                await window.electronSystemAPI.callDialogError('시스템 오류', '시스템 내부 오류.');
                 return;
             }
 

--- a/src/rendererArea/sidebar/pages/editor/EditorPageStore.ts
+++ b/src/rendererArea/sidebar/pages/editor/EditorPageStore.ts
@@ -121,7 +121,7 @@ export const useEditorPageStore = create<EditorPageStore>((set, get) => ({
 
         const updateJob = await window.electronBoringDataAPI.updateBoring(boring.serialize());
         if(updateJob.updateError) {
-            alert(updateJob.updateError.message);
+            window.electronSystemAPI.callDialogError('시추공 수정 오류', updateJob.updateError.message);
             set(() => {
                 return {updateEventListners: []}
             });

--- a/src/rendererArea/sidebar/pages/editor/inspectors/inspectorBoringEdit.tsx
+++ b/src/rendererArea/sidebar/pages/editor/inspectors/inspectorBoringEdit.tsx
@@ -58,25 +58,25 @@ export const InspectorBoringEdit: React.FC<BoringEditorProps> = ({boring, isNewC
     const onClickSave = async () => {
         // Layer check
         if(boring.getLayers().length == 0) {
-            alert('레이어는 1개이상 배치해야 합니다.');
+            await window.electronSystemAPI.callDialogError('시추공 레이어 오류', '레이어는 1개이상 배치해야 합니다.');
             return;
         }
 
         // Name Check
         const newName = boring.getName();
         if(newName.length == 0 || newName.trim().length == 0) {
-            alert('이름은 공란이나 여백으로 만들 수 없습니다.')
+            await window.electronSystemAPI.callDialogError('시추공 이름 오류', '이름은 공란이나 여백으로 만들 수 없습니다.')
             return;
         }
         
         const searchNameJob = await searchBoringName(boring.getName(), boring.getId().getValue());
         if(searchNameJob == 'found') {
-            alert('이미 사용중인 시추공 이름입니다.');
+            await window.electronSystemAPI.callDialogError('시추공 이름 오류', '이미 사용중인 시추공 이름입니다.');
             return;
         }
 
         if(searchNameJob == 'internalError') {
-            alert('시스템 내부 오류.');
+            await window.electronSystemAPI.callDialogError('Commonland 시스템 오류', '시스템 내부 오류.');
             return;
         }
             
@@ -109,7 +109,7 @@ export const InspectorBoringEdit: React.FC<BoringEditorProps> = ({boring, isNewC
             }
         
             alertMessage += '해당 항목을 확인해 주세요.';
-            alert(alertMessage);
+            await window.electronSystemAPI.callDialogError('레이어 입력 오류', alertMessage);
         
             return;
         }
@@ -125,7 +125,7 @@ export const InspectorBoringEdit: React.FC<BoringEditorProps> = ({boring, isNewC
         }
 
         if(!toleranceCheckResult) {
-            alert('인접한 시추공과 0.5m 이상 떨어져있어야 합니다.');
+            await window.electronSystemAPI.callDialogError('시추공 위치 오류', '인접한 시추공과 0.5m 이상 떨어져있어야 합니다.');
             return;
         }
 

--- a/src/rendererArea/sidebar/pages/topography/inspector/inspectorTopoMaker.tsx
+++ b/src/rendererArea/sidebar/pages/topography/inspector/inspectorTopoMaker.tsx
@@ -32,10 +32,10 @@ export const InspectorTopoMaker:React.FC<InspectorTopoMakerProp> = ({onSubmitTop
         reset,
     } = useTopoMakerStore();
 
-    const onSubmit = () => {
+    const onSubmit = async () => {
         const topoName = nameRef.current.value;
         if(topoName.length == 0) {
-            alert('이름은 공백으로 설정할 수 없습니다.');
+            await window.electronSystemAPI.callDialogError('시추공 이름 오류', '이름은 공백으로 설정할 수 없습니다.');
             return;
         }
 
@@ -53,7 +53,7 @@ export const InspectorTopoMaker:React.FC<InspectorTopoMakerProp> = ({onSubmitTop
             if(onSubmitTopo) onSubmitTopo(topo);
             toggleMode(false);
         } else {
-            alert('모든 시추공에서 레이어를 선택헤 주세요');
+            await window.electronSystemAPI.callDialogError('지형면 생성 오류', '모든 시추공에서 레이어를 선택헤 주세요');
         }
     };
 


### PR DESCRIPTION
# Replaced alerting dialog

Before : call alert at renderer process.
After : call dialog at main process.

### WHY
- Basically window.alert() blocks the execution thread of application until a user's input comes.
- Electron does not support the restore from this blocked status. Thus, Electron app losts its focusing on window and makes user can not click input tag (Focus is disabled and can not enable it). Instead, we can call dialog.showMessageBox() at main process.

```typescript
export const setIpcModalControl = (ipcMain: IpcMain) => {
    ipcMain.handle('call-dialog-error', async (_, title, message) => {
        await dialog.showMessageBox(UIController.instance.getWindow('main-window'), {
            type: "error",
            title: title,
            message: message,
            buttons: ["OK"],
        });
    });
}
```

![image](https://github.com/user-attachments/assets/986bf9b3-1fd8-4e37-84ca-572cec8ff147)

By applicating this, we can restore the original state. And the modal appears as window's native modal.